### PR TITLE
[#169058711] Ansible Service Manager / SystemD Pre Start Fix

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,4 @@
 # vim: ft=ansible:et:ts=2
-
-- set_fact:
-    is_ubuntu1804: "{{ ansible_distribution_version == '18.04' }}"
-
 - name: Create Mongos log directory
   file: path="{{ _mongos.log_path }}" state=directory owner="{{ _mongos.user }}" group="{{ _mongos.group }}" mode=0750
 
@@ -17,11 +13,11 @@
 
 - name: Create Mongos systemd script
   template: src="etc/systemd/system/mongos.service.j2" dest="/etc/systemd/system/mongos.service" owner=root group="{{ _mongos.group }}" mode=0644
-  when: is_ubuntu1804
+  when: ansible_service_mgr == "systemd"
 
 - name: Create Mongos systemd helper script
   template: src="usr/local/bin/mongos-pre-start.sh.j2" dest="/usr/local/bin/mongos-pre-start.sh" owner=root group="{{ _mongos.group }}" mode=0754
-  when: is_ubuntu1804
+  when: ansible_service_mgr == "systemd"
 
 - block:
     - name: Copy Mongos SSL PEMKeyFile
@@ -36,8 +32,8 @@
 
 - name: Disable Service Autostart
   systemd: name="mongos" enabled=no no_block=true
-  when: is_ubuntu1804
+  when: ansible_service_mgr == "systemd"
 
 - name: Disable Service Autostart
   service: name="mongos" enabled=no
-  when: not is_ubuntu1804
+  when: ansible_service_mgr == "upstart"

--- a/templates/usr/local/bin/mongos-pre-start.sh.j2
+++ b/templates/usr/local/bin/mongos-pre-start.sh.j2
@@ -1,6 +1,5 @@
 #!/bin/bash -e
 
-if [ ! -d {{ _mongos.log_path }}; then
+if [ ! -d {{ _mongos.log_path }} ]; then
   mkdir -p {{ _mongos.log_path }} && chown {{_mongos.user}}:{{ _mongos.group }} {{ _mongos.log_path }}
 fi
-


### PR DESCRIPTION
- nutze `ansible_service_mgr` für Erkennung ob SystemD oder Upstart Tasks ausgeführt werden
- typo in `templates/usr/local/bin/mongos-pre-start.sh.j2` gefixed
- getestet mit  `rest` (14.04), `batch` (18.04),  und `document_server` (20.04 POC)