### PR TITLE
[#180207924] Add systemd unit Exec steps to create mongos pidfile

### DIFF
--- a/templates/etc/systemd/system/mongos.service.j2
+++ b/templates/etc/systemd/system/mongos.service.j2
@@ -33,6 +33,10 @@ PermissionsStartOnly=true
 ExecStartPre=/usr/local/bin/mongos-pre-start.sh
 ExecStart=/usr/bin/mongos --config /etc/mongos.conf
 
+# logrotate needs pidfile to send USR1 signal after rotation
+ExecStartPost=/usr/bin/sh -c "/usr/bin/echo -n $MAINPID > /var/run/mongos.pid"
+ExecStopPost=rm /var/run/mongos.pid
+
 [Install]
 WantedBy=multi-user.target
 


### PR DESCRIPTION
Systemd does not create a pidfile but logrotate relies on it to send the rotation signal (`USR1`) to mongos.

This PR adds Exec actions to the systemd unit to create a pidfile.

_Tested as described in ticket_

Note: This will be released as `v0.0.10`

---

An alternative implementation would use systemd's `PIDFile` in combination with mongos `processManagement.pidFilePath`.
We decided to use this PR since it poses a smaller risk.