### PR TITLE
[#180207924] Use absolute path as required by systemd on Ubuntu 18.04

### DIFF
--- a/templates/etc/systemd/system/mongos.service.j2
+++ b/templates/etc/systemd/system/mongos.service.j2
@@ -35,7 +35,7 @@ ExecStart=/usr/bin/mongos --config /etc/mongos.conf
 
 # logrotate needs pidfile to send USR1 signal after rotation
 ExecStartPost=/usr/bin/sh -c "/usr/bin/echo -n $MAINPID > /var/run/mongos.pid"
-ExecStopPost=rm /var/run/mongos.pid
+ExecStopPost=/usr/bin/rm /var/run/mongos.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fixes issues with Ubuntu 18.04 as seen in CI https://github.com/Rheinwerk/ansible-role-update_mongos_config/pull/3/checks

Note: Tagging/Releasing as `v0.0.11` once merged.