### PR TITLE
[#180207924] Fix Ubuntu 18.04 compatibility

### DIFF
--- a/templates/etc/systemd/system/mongos.service.j2
+++ b/templates/etc/systemd/system/mongos.service.j2
@@ -34,8 +34,8 @@ ExecStartPre=/usr/local/bin/mongos-pre-start.sh
 ExecStart=/usr/bin/mongos --config /etc/mongos.conf
 
 # logrotate needs pidfile to send USR1 signal after rotation
-ExecStartPost=/usr/bin/sh -c "/usr/bin/echo -n $MAINPID > /var/run/mongos.pid"
-ExecStopPost=/usr/bin/rm /var/run/mongos.pid
+ExecStartPost=/bin/sh -c "/bin/echo -n $MAINPID > /var/run/mongos.pid"
+ExecStopPost=/bin/rm /var/run/mongos.pid
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
`rm`, `echo`, `sh` are located in `/bin` on ubuntu 18.04.
Ubuntu 20.04 symlinks `/bin` to `/usr/bin` which contains the tools.

This commit works for both versions.

(will be released as `v0.0.12`)